### PR TITLE
Change k6 dependency to v0.45.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,27 @@
 module github.com/frankhefeng/xk6-oauth-pkce
 
-go 1.18
+go 1.19
+
+require go.k6.io/k6 v0.45.1
+
+require (
+	github.com/dlclark/regexp2 v1.9.0 // indirect
+	github.com/dop251/goja v0.0.0-20230531210528-d7324b2d74f7 // indirect
+	github.com/fatih/color v1.15.0 // indirect
+	github.com/go-sourcemap/sourcemap v2.1.4-0.20211119122758-180fcef48034+incompatible // indirect
+	github.com/google/pprof v0.0.0-20230207041349-798e818bf904 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.18 // indirect
+	github.com/mstoykov/atlas v0.0.0-20220811071828-388f114305dd // indirect
+	github.com/onsi/ginkgo v1.16.5 // indirect
+	github.com/onsi/gomega v1.27.10 // indirect
+	github.com/serenize/snaker v0.0.0-20201027110005-a7ad2135616e // indirect
+	github.com/sirupsen/logrus v1.9.0 // indirect
+	github.com/spf13/afero v1.1.2 // indirect
+	golang.org/x/sys v0.10.0 // indirect
+	golang.org/x/text v0.11.0 // indirect
+	golang.org/x/time v0.3.0 // indirect
+	gopkg.in/guregu/null.v3 v3.3.0 // indirect
+)


### PR DESCRIPTION
A transitive dependency was removed. v0.45.0 was patched to address the issue. See grafana/k6#3252.
